### PR TITLE
Modernize project to SDK-style and update dependencies

### DIFF
--- a/Authorize.NET/AuthorizeNET.csproj
+++ b/Authorize.NET/AuthorizeNET.csproj
@@ -1,132 +1,35 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{5D52EAEC-42FB-4313-83B8-69E2F55EBF14}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AuthorizeNet</RootNamespace>
-    <AssemblyName>AuthorizeNet</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>3.5</OldToolsVersion>
+    <Configurations>Debug;Release;USELOCAL</Configurations>
+    <AssemblyTitle>Official .NET SDK for Authorize.Net</AssemblyTitle>
+    <Company>Visa Inc</Company>
+    <Product>Official .NET SDK for Authorize.Net</Product>
+    <Copyright>Copyright © Visa Inc 2018</Copyright>
+    <FileVersion>2.0.4.0</FileVersion>
+    <AssemblyVersion>2.0.4.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>bin/Debug/</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin/Debug/AuthorizeNet.XML</DocumentationFile>
     <NoWarn>0219,1591,1635</NoWarn>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
     <OutputPath>bin/Release</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin/Release/AuthorizeNet.XML</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Security" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters" Version="1.3.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Environment.cs" />
-    <Compile Include="MarketType.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestFriends.cs" />
-    <Compile Include="Api\Contracts\V1\*.cs" />
-    <Compile Include="Api\Controllers\ARBCancelSubscriptionController.cs" />
-    <Compile Include="Api\Controllers\ARBCreateSubscriptionController.cs" />
-    <Compile Include="Api\Controllers\ARBGetSubscriptionController.cs" />
-    <Compile Include="Api\Controllers\ARBGetSubscriptionListController.cs" />
-    <Compile Include="Api\Controllers\ARBGetSubscriptionStatusController.cs" />
-    <Compile Include="Api\Controllers\ARBUpdateSubscriptionController.cs" />
-    <Compile Include="Api\Controllers\authenticateTestController.cs" />
-    <Compile Include="Api\Controllers\createCustomerPaymentProfileController.cs" />
-    <Compile Include="Api\Controllers\createCustomerProfileController.cs" />
-    <Compile Include="Api\Controllers\createCustomerProfileFromTransactionController.cs" />
-    <Compile Include="Api\Controllers\createCustomerProfileTransactionController.cs" />
-    <Compile Include="Api\Controllers\createCustomerShippingAddressController.cs" />
-    <Compile Include="Api\Controllers\createProfileController.cs" />
-    <Compile Include="Api\Controllers\createTransactionController.cs" />
-    <Compile Include="Api\Controllers\decryptPaymentDataController.cs" />
-    <Compile Include="Api\Controllers\deleteCustomerPaymentProfileController.cs" />
-    <Compile Include="Api\Controllers\deleteCustomerProfileController.cs" />
-    <Compile Include="Api\Controllers\deleteCustomerShippingAddressController.cs" />
-    <Compile Include="Api\Controllers\getAUJobDetailsController.cs" />
-    <Compile Include="Api\Controllers\getAUJobSummaryController.cs" />
-    <Compile Include="Api\Controllers\getBatchStatisticsController.cs" />
-    <Compile Include="Api\Controllers\getCustomerPaymentProfileController.cs" />
-    <Compile Include="Api\Controllers\getCustomerPaymentProfileListController.cs" />
-    <Compile Include="Api\Controllers\getCustomerPaymentProfileNonceController.cs" />
-    <Compile Include="Api\Controllers\getCustomerProfileController.cs" />
-    <Compile Include="Api\Controllers\getCustomerProfileIdsController.cs" />
-    <Compile Include="Api\Controllers\getCustomerShippingAddressController.cs" />
-    <Compile Include="Api\Controllers\getHostedPaymentPageController.cs" />
-    <Compile Include="Api\Controllers\getHostedProfilePageController.cs" />
-    <Compile Include="Api\Controllers\getMerchantDetailsController.cs" />
-    <Compile Include="Api\Controllers\getSettledBatchListController.cs" />
-    <Compile Include="Api\Controllers\getTransactionDetailsController.cs" />
-    <Compile Include="Api\Controllers\getTransactionListController.cs" />
-    <Compile Include="Api\Controllers\getTransactionListForCustomerController.cs" />
-    <Compile Include="Api\Controllers\getUnsettledTransactionListController.cs" />
-    <Compile Include="Api\Controllers\isAliveController.cs" />
-    <Compile Include="Api\Controllers\logoutController.cs" />
-    <Compile Include="Api\Controllers\mobileDeviceLoginController.cs" />
-    <Compile Include="Api\Controllers\mobileDeviceRegistrationController.cs" />
-    <Compile Include="Api\Controllers\securePaymentContainerController.cs" />
-    <Compile Include="Api\Controllers\sendCustomerTransactionReceiptController.cs" />
-    <Compile Include="Api\Controllers\transactionController.cs" />
-    <Compile Include="Api\Controllers\updateCustomerPaymentProfileController.cs" />
-    <Compile Include="Api\Controllers\updateCustomerProfileController.cs" />
-    <Compile Include="Api\Controllers\updateCustomerShippingAddressController.cs" />
-    <Compile Include="Api\Controllers\updateHeldTransactionController.cs" />
-    <Compile Include="Api\Controllers\updateMerchantDetailsController.cs" />
-    <Compile Include="Api\Controllers\updateSplitTenderGroupController.cs" />
-    <Compile Include="Api\Controllers\validateCustomerPaymentProfileController.cs" />
-    <Compile Include="Api\Controllers\Bases\*.cs" />
-    <Compile Include="Utility\AnetRandom.cs" />
-    <Compile Include="Utility\CryptoRandom.cs" />
-    <Compile Include="Util\*.cs" />
-    <Compile Include="Utility\AnetApiSchema.generated.cs" />
-    <Compile Include="Utility\ApiFields.cs" />
+    <Compile Remove="Api\Controllers\createFingerPrintController.cs" />
+    <Compile Remove="Api\Controllers\transactionResponseEmvController.cs" />
   </ItemGroup>
-  <ItemGroup />
-  <ItemGroup>
-    <None Include="Api\ControllerTemplate.cst" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!--Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" /-->
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Authorize.NET/Properties/AssemblyInfo.cs
+++ b/Authorize.NET/Properties/AssemblyInfo.cs
@@ -1,16 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Official .NET SDK for Authorize.Net")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Visa Inc")]
-[assembly: AssemblyProduct("Official .NET SDK for Authorize.Net")]
-[assembly: AssemblyCopyright("Copyright © Visa Inc 2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -21,16 +11,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("135241b2-017e-4f07-aca1-e71887b470ab")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// See AssemblyFileVersion.cs for Product and Assembly Version
-//[assembly: AssemblyVersion("2.0.2.0")]
-[assembly: AssemblyFileVersion("2.0.4.0")]
-[assembly: AssemblyVersion("2.0.4.0")]
 

--- a/AuthorizeNET.sln
+++ b/AuthorizeNET.sln
@@ -1,9 +1,9 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.10.35027.167
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthorizeNET", "Authorize.NET\AuthorizeNET.csproj", "{5D52EAEC-42FB-4313-83B8-69E2F55EBF14}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthorizeNET", "Authorize.NET\AuthorizeNET.csproj", "{5D52EAEC-42FB-4313-83B8-69E2F55EBF14}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthorizeNETtest", "AuthorizeNETtest\AuthorizeNETtest.csproj", "{CDA0D4D8-E4AA-4BEA-8839-04D69607D914}"
 EndProject


### PR DESCRIPTION
Updated `AuthorizeNET.csproj` to use the SDK-style project format, simplifying its structure. Removed obsolete properties and elements, and added new properties like `AssemblyTitle`, `Company`, and `Product`. Set `TargetFramework` to `netstandard2.0` and disabled `GenerateAssemblyInfo`.

Replaced `ItemGroup` references with `PackageReference` for `System.Data.DataSetExtensions`, `Microsoft.AspNetCore.SystemWebAdapters`, and `System.Configuration.ConfigurationManager`. Excluded specific source files using `Compile` elements with `Remove` attribute.

Removed `Import` for `Microsoft.CSharp.targets` and cleaned up commented-out elements. Updated `AuthorizeNET.sln` to reflect the new project type GUID.